### PR TITLE
health apis enable

### DIFF
--- a/src/main/java/org/cdpg/dx/auditingserver/apiserver/ApiServerVerticle.java
+++ b/src/main/java/org/cdpg/dx/auditingserver/apiserver/ApiServerVerticle.java
@@ -96,12 +96,12 @@ public class ApiServerVerticle extends AbstractVerticle {
                 LOGGER.debug("Creating router...");
                 router = routerBuilder.createRouter();
 
-             /*   // Attach health endpoints before static handler
+                // Attach health endpoints before static handler
                 PostgresService postgresService =
                     PostgresService.createProxy(vertx, POSTGRES_SERVICE_ADDRESS);
                 HealthService healthService = new HealthServiceImpl(vertx, postgresService);
                 HealthController healthController = new HealthController(router, healthService);
-                healthController.init();*/
+                healthController.init();
 
                 // Serve Redoc JS and other static files (with caching disabled for dev)
                 router

--- a/src/main/java/org/cdpg/dx/database/postgres/util/EntityUtil.java
+++ b/src/main/java/org/cdpg/dx/database/postgres/util/EntityUtil.java
@@ -29,7 +29,7 @@ public class EntityUtil {
     if (value != null && !value.isEmpty()) {
       return UUID.fromString(value);
     }
-    LOGGER.warn("requested UUID is null or empty for {}", name);
+    LOGGER.debug("requested UUID is null or empty for {}", name);
     return null;
   }
 }


### PR DESCRIPTION
Enable internal health APIs
- Added readiness and liveness endpoints for internal monitoring
- Health checks include Postgres and RabbitMQ readiness

**NOTE** : **Endpoints are exposed only for internal access**